### PR TITLE
Remove deprecated version key from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,6 @@
     "angular",
     "notification"
   ],
-  "version": "1.1.0",
   "main": "dist/angular-tinycon.min.js",
   "ignore": [
     "src",


### PR DESCRIPTION
See https://github.com/bower/spec/blob/master/json.md#version

Now that version is out of sync with actually tagged version, getting this when installing:

```
bower checkout      tinycon-angularjs#1.1.1
bower mismatch      Version declared in the json (1.1.0) is different than the resolved one (1.1.1)
bower resolved      https://github.com/dirkgroenen/tinycon-angularjs.git#1.1.1
bower install       angular-tinycon#1.1.1
```
