### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,9 @@
 {
   "name": "angular-tinycon",
-  "repo": "dirkgroenen/angular-tinycon",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dirkgroenen/angular-tinycon.git"
+  },
   "description": "TinyCon module for AngularJS.",
   "keywords": [
     "favicon",
@@ -8,11 +11,18 @@
     "angular",
     "notification"
   ],
-  "version": "1.1.0",
-  "main": "dist/angular-tinycon.min.js",
+  "main": "src/angular-tinycon.js",
+  "dependencies": {
+    "angular": "1.x",
+    "tinycon": "~0.6.5"
+  },
   "ignore": [
-    "src",
     "tinycon",
-    "demo"
+    "demo",
+    ".gitmodules",
+    ".gitignore",
+    "*.md",
+    "Gruntfile.js",
+    "package.json"
   ]
 }


### PR DESCRIPTION
See https://github.com/bower/spec/blob/master/json.md
- Modify ignore list. Previously it includes only minified version with tinyicon library included, which is quite against convention. Bower team encourages not to include minified version at all. For dependencies you should use "dependencies" key instead.
- Add dependencies key. Quite flexible versioning should work.
- Remove deprecated version key. Now that version is out of sync with actually tagged version, getting this when installing:

```
bower checkout      tinycon-angularjs#1.1.1
bower mismatch      Version declared in the json (1.1.0) is different than the resolved one (1.1.1)
bower resolved      https://github.com/dirkgroenen/tinycon-angularjs.git#1.1.1
bower install       angular-tinycon#1.1.1
```
- Cleaning out repo key
- Point main version to non-minified (breaking change, requires major version bump)
